### PR TITLE
feat(lwc): add parent-child components with infinite loop prevention

### DIFF
--- a/force-app/main/default/lwc/childRender/childRender.html
+++ b/force-app/main/default/lwc/childRender/childRender.html
@@ -1,0 +1,5 @@
+<template>
+    <div>
+        <p>Child Value: {value}</p>
+    </div>
+</template>

--- a/force-app/main/default/lwc/childRender/childRender.js
+++ b/force-app/main/default/lwc/childRender/childRender.js
@@ -1,0 +1,40 @@
+import { LightningElement, api } from 'lwc';
+
+export default class ChildRender extends LightningElement {
+    _value;
+    isInternalUpdate = false; // ✅ key flag
+
+    @api
+    get value() {
+        return this._value;
+    }
+
+    set value(newValue) {
+        // ✅ Ignore if same value
+        if (this._value === newValue) {
+            return;
+        }
+
+        console.log('Child received:', newValue);
+        this._value = newValue;
+
+        // ✅ Prevent loop: only emit if NOT internal update
+        if (!this.isInternalUpdate) {
+            this.isInternalUpdate = true;
+
+            // simulate auto update logic
+            const updatedValue = newValue + 1;
+
+            this.dispatchEvent(
+                new CustomEvent('valuechange', {
+                    detail: updatedValue
+                })
+            );
+
+            // reset flag after microtask
+            Promise.resolve().then(() => {
+                this.isInternalUpdate = false;
+            });
+        }
+    }
+}

--- a/force-app/main/default/lwc/childRender/childRender.js-meta.xml
+++ b/force-app/main/default/lwc/childRender/childRender.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>

--- a/force-app/main/default/lwc/parentRender/parentRender.html
+++ b/force-app/main/default/lwc/parentRender/parentRender.html
@@ -1,0 +1,6 @@
+<template>
+    <div>
+        <h2>Parent Value: {value}</h2>
+        <c-child-render value={value} onvaluechange={handleValueChange}></c-child-render>
+    </div>
+</template>

--- a/force-app/main/default/lwc/parentRender/parentRender.js
+++ b/force-app/main/default/lwc/parentRender/parentRender.js
@@ -1,0 +1,15 @@
+import { LightningElement, track } from 'lwc';
+
+export default class ParentRender extends LightningElement {
+    @track value = 0;
+
+    handleValueChange(event) {
+        const newValue = event.detail;
+
+        // ✅ Guard: prevent redundant updates
+        if (this.value !== newValue) {
+            console.log('Parent updating:', newValue);
+            this.value = newValue;
+        }
+    }
+}

--- a/force-app/main/default/lwc/parentRender/parentRender.js-meta.xml
+++ b/force-app/main/default/lwc/parentRender/parentRender.js-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <isExposed>true</isExposed>
+	<targets>
+		<target>lightning__AppPage</target>
+	</targets>
+</LightningComponentBundle>


### PR DESCRIPTION
Add parentRender and childRender LWC components demonstrating proper bidirectional data flow between parent and child components. Implements safeguards to prevent infinite render loops:

- Parent component tracks a value and handles updates from child
- Child component uses @api property with custom getter/setter
- Internal update flag prevents recursive event dispatching
- Value change guards ensure updates only occur when value differs
- Child auto-increments value and emits change event to parent

This pattern ensures reactive updates while avoiding common pitfalls in bidirectional parent-child communication.